### PR TITLE
libril: Fix SIM PIN for MODEM_TYPE_XMM6260

### DIFF
--- a/ril/libril/ril_service.cpp
+++ b/ril/libril/ril_service.cpp
@@ -839,8 +839,13 @@ Return<void> RadioImpl::supplyIccPinForApp(int32_t serial, const hidl_string& pi
 #if VDBG
     RLOGD("supplyIccPinForApp: serial %d", serial);
 #endif
+#ifdef MODEM_TYPE_XMM6260
+    dispatchStrings(serial, mSlotId, RIL_REQUEST_ENTER_SIM_PIN, false,
+            2, pin.c_str(), aid.c_str());
+#else
     dispatchStrings(serial, mSlotId, RIL_REQUEST_ENTER_SIM_PIN, true,
             2, pin.c_str(), aid.c_str());
+#endif
     return Void();
 }
 


### PR DESCRIPTION
Change-Id: I1acba16942b46eb62d5b64e17ea565664a5cf808